### PR TITLE
lib/init.sh: fix parsing kernel cmdline

### DIFF
--- a/lib/init.sh
+++ b/lib/init.sh
@@ -49,7 +49,7 @@ parse_cmdline()
         # Maintain backward compatibility with kernel parameters.
         ro | rw)      rorw=$_param ;;
         rootwait)     root_wait=-1 ;;
-        --)           init_args=${_param##*--}; break ;;
+        --)           init_args=${cmdline##*--}; break ;;
         rootfstype=*) root_type=${_param#*=} ;;
         rootflags=*)  root_opts=${_param#*=} ;;
         rootdelay=*)  root_wait=${_param#*=} ;;


### PR DESCRIPTION
> The kernel parses parameters from the kernel command line up to "--"; if it doesn't recognize a parameter and it doesn't contain a '.', the parameter gets passed to init: parameters with '=' go into init's environment, others are passed as command line arguments to init. Everything after "--" is passed as an argument to init.

Args **after** `--` should be passed to the init process as `init_args`.