### PR TITLE
hook/{luks,lvm}: drop hostonly when copy_kmod

### DIFF
--- a/hook/luks/luks
+++ b/hook/luks/luks
@@ -22,13 +22,12 @@
     mv "${tmpdir}/_" "${tmpdir}/etc/tinyramfs/config"
 }
 
-[ "$hostonly" ] &&
-    for _mod in \
-        aes ecb xts lrw wp512 sha256 \
-        sha512 twofish serpent dm-crypt
-    do
-        copy_kmod "$_mod"
-    done
+for _mod in \
+    aes ecb xts lrw wp512 sha256 \
+    sha512 twofish serpent dm-crypt
+do
+    copy_kmod "$_mod"
+done
 
 # https://bugs.archlinux.org/task/56771
 [ -e /lib/libgcc_s.so.1 ] && copy_file /lib/libgcc_s.so.1 /lib/libgcc_s.so.1 0755 1

--- a/hook/lvm/lvm
+++ b/hook/lvm/lvm
@@ -4,13 +4,12 @@
 # https://shellcheck.net/wiki/SC2154
 # shellcheck disable=2154
 
-[ "$hostonly" ] &&
-    for _mod in \
-        dm-log dm-cache dm-mirror \
-        dm-snapshot dm-multipath dm-thin-pool
-    do
-        copy_kmod "$_mod"
-    done
+for _mod in \
+    dm-log dm-cache dm-mirror \
+    dm-snapshot dm-multipath dm-thin-pool
+do
+    copy_kmod "$_mod"
+done
 
 copy_exec lvm
 


### PR DESCRIPTION
I think those hooks should copy the necessary modules in any case.
This fixes https://github.com/illiliti/tinyramfs/issues/34 for me on Void Linux,
namely I can drop `hostonly` from config and the initram still boots.

@illiliti Makes sense?